### PR TITLE
Add Phase 0 architecture sprint docs and Orpheon bootstrap placeholder; update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.DS_Store
 *.m~
+
+# Python cache/bytecode
+__pycache__/
+*.py[cod]

--- a/docs/phase0/README.md
+++ b/docs/phase0/README.md
@@ -1,0 +1,21 @@
+# Phase 0 Architecture Sprint Starter Pack
+
+This folder starts the 1–2 week architecture sprint proposed in `docs/python-port-feasibility.md`.
+
+## Included artifacts
+- `adr/ADR-001`..`ADR-007`: initial decision drafts to review and ratify.
+- `api-mockups.md`: first-pass high-level API shape.
+- `operator-plugin-skeletons.py`: minimal protocol/skeleton examples for operators and plugins.
+- `batch-execution-prototype-spec.md`: first executable-thinking spec for large batch workflows.
+- `mirtoolbox-migration-examples.md`: starter migration mappings for common MIRtoolbox-style tasks.
+- `project-naming-options.md`: Python-ecosystem-inspired naming shortlist and recommendation for the new GitHub project.
+- `orpheon-validation-checklist.md`: practical validation checks for the selected `Orpheon` name (with environment constraints noted).
+
+- `pypi-reservation-automation.md`: step-by-step PyPI reservation automation guide and publish options.
+- `orpheon-bootstrap/`: copy-ready placeholder package, GitHub Action, and local bootstrap helper script for first PyPI release.
+
+## How to use this pack
+1. Review ADRs in order (001 → 007).
+2. Edit unresolved items and decision options during architecture meetings.
+3. Approve ADRs before implementation-heavy coding begins.
+4. Use mockups/specs as constraints for first prototype implementation.

--- a/docs/phase0/adr/ADR-001-scope-and-non-goals.md
+++ b/docs/phase0/adr/ADR-001-scope-and-non-goals.md
@@ -1,0 +1,19 @@
+# ADR-001: Scope and Non-goals
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+MiningSuite is being redesigned as a Python-native framework focused on simplicity, scalability, and extensibility.
+
+## Decision
+- Build a new Python-native framework.
+- Prioritize simple command UX, batch analysis, and extensibility.
+- Treat real-time processing and strict MATLAB parity as non-goals for v1.
+
+## Consequences
+- Faster design evolution and cleaner architecture.
+- Need migration guides for legacy users.
+
+## Open questions
+- Which legacy features are mandatory in v1 vs v1.x?

--- a/docs/phase0/adr/ADR-002-api-philosophy.md
+++ b/docs/phase0/adr/ADR-002-api-philosophy.md
@@ -1,0 +1,19 @@
+# ADR-002: API Philosophy (Guided Familiarity)
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+Users from MIRtoolbox should onboard quickly, but legacy compatibility must not degrade architecture quality.
+
+## Decision
+- Adopt guided familiarity: recognizable concepts and names where useful.
+- Prefer consistent Pythonic API patterns over historical quirks.
+- Provide migration mappings and examples.
+
+## Consequences
+- Easier migration for existing users.
+- Some legacy commands will require small rewrites.
+
+## Open questions
+- Define final naming conventions and deprecation policy language.

--- a/docs/phase0/adr/ADR-003-core-data-model.md
+++ b/docs/phase0/adr/ADR-003-core-data-model.md
@@ -1,0 +1,19 @@
+# ADR-003: Core Data Model and Provenance
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+A robust data model is required for reproducibility, multimodality, and cross-operator composability.
+
+## Decision
+- Introduce typed containers (`Signal`, `Feature`, `Sequence`, `Collection`).
+- Require explicit axes, units, labels, and provenance metadata.
+- Ensure outputs include operation lineage (operator, params, version, timestamp/hash).
+
+## Consequences
+- Better reproducibility and debuggability.
+- Slightly more upfront schema design.
+
+## Open questions
+- Should data containers be strictly immutable or copy-on-write?

--- a/docs/phase0/adr/ADR-004-operator-and-graph-semantics.md
+++ b/docs/phase0/adr/ADR-004-operator-and-graph-semantics.md
@@ -1,0 +1,19 @@
+# ADR-004: Operator Contract and Graph Semantics
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+Operators must remain easy to use while supporting complex pipelines and large-scale execution.
+
+## Decision
+- Operators expose explicit input/output schemas.
+- Pipeline execution is graph-based with lazy-by-default semantics.
+- Eager execution is available for interactive workflows.
+
+## Consequences
+- Enables caching and optimization.
+- Requires strict validation and schema discipline.
+
+## Open questions
+- What should be the default materialization points in interactive use?

--- a/docs/phase0/adr/ADR-005-plugin-system.md
+++ b/docs/phase0/adr/ADR-005-plugin-system.md
@@ -1,0 +1,19 @@
+# ADR-005: Plugin System and Extension Points
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+The project should be genuinely open source and easy to extend with new analysis modules/modalities.
+
+## Decision
+- Define a stable plugin interface for out-of-tree operators.
+- Use registration/discovery mechanisms for community extensions.
+- Require plugin metadata and minimum test coverage for publication.
+
+## Consequences
+- Lower contributor friction.
+- Need governance for plugin quality and API changes.
+
+## Open questions
+- Will official plugin indexing be repository-based or package-index based?

--- a/docs/phase0/adr/ADR-006-batch-and-caching.md
+++ b/docs/phase0/adr/ADR-006-batch-and-caching.md
@@ -1,0 +1,19 @@
+# ADR-006: Batch Execution and Caching Strategy
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+Primary performance goal is efficient offline analysis at corpus scale.
+
+## Decision
+- First-class batch executor with resumable jobs.
+- Content-addressed caching of intermediate node outputs.
+- Deterministic job manifests and run summaries.
+
+## Consequences
+- Major throughput gains on large corpora.
+- Requires careful cache invalidation/versioning design.
+
+## Open questions
+- Which cache backend(s) should be supported in v1?

--- a/docs/phase0/adr/ADR-007-api-stability-policy.md
+++ b/docs/phase0/adr/ADR-007-api-stability-policy.md
@@ -1,0 +1,19 @@
+# ADR-007: API Stability and Deprecation Policy
+
+- **Status:** Proposed
+- **Date:** 2026-03-05
+
+## Context
+After initial development, users need a stable API and predictable evolution.
+
+## Decision
+- Semantic versioning from v1.0 onward.
+- Public API surface explicitly documented.
+- Deprecations require warning period and migration notes.
+
+## Consequences
+- Higher trust and adoption.
+- Requires discipline in release management.
+
+## Open questions
+- Define exact deprecation window duration (e.g., 1 minor, 2 minors).

--- a/docs/phase0/api-mockups.md
+++ b/docs/phase0/api-mockups.md
@@ -1,0 +1,43 @@
+# API Mockups (Phase 0)
+
+## Design targets
+- One-liner for common tasks.
+- Chainable pipelines for advanced use.
+- Explicit but concise parameterization.
+
+## Mockup A: one-liner
+```python
+import ms
+result = ms.audio("song.wav").spectrum().centroid().compute()
+```
+
+## Mockup B: declarative pipeline
+```python
+import ms
+
+pipe = (
+    ms.pipeline("song.wav")
+      .frame(size=0.05, hop=0.01)
+      .spectrum(scale="mel")
+      .flux()
+      .tempo()
+)
+out = pipe.compute()
+```
+
+## Mockup C: corpus mode
+```python
+job = (
+    ms.batch("/data/corpus/**/*.wav")
+      .pipeline(lambda x: x.spectrum().mfcc().pitch())
+      .cache(".ms_cache")
+      .workers(16)
+)
+summary = job.run(resume=True)
+```
+
+## Mockup D: modality adapters
+```python
+score = ms.midi("piece.mid").pianoroll().key().compute()
+motion = ms.mocap("gesture.c3d").velocity().events().compute()
+```

--- a/docs/phase0/batch-execution-prototype-spec.md
+++ b/docs/phase0/batch-execution-prototype-spec.md
@@ -1,0 +1,23 @@
+# Batch Execution Prototype Spec (Phase 0)
+
+## Objectives
+- Analyze very large collections of files.
+- Resume from partial failures.
+- Reuse cached intermediates when pipeline and inputs match.
+
+## Prototype scope
+1. Input expansion (`glob`, manifest file, or directory scan).
+2. Pipeline fingerprint/hash from operator graph + parameters + version.
+3. Per-file execution records with status (`ok`, `failed`, `cached`, `skipped`).
+4. Resume mode that only executes missing/invalidated nodes.
+5. Summary report export (JSON + CSV).
+
+## Minimal CLI sketch
+```bash
+ms batch run --inputs "/data/**/*.wav" --pipeline pipeline.yml --cache .ms_cache --workers 8 --resume
+```
+
+## Success criteria
+- Re-run on unchanged corpus is mostly cache hits.
+- Single-file failures do not invalidate whole job.
+- Summary output can be consumed in notebook/statistics workflows.

--- a/docs/phase0/mirtoolbox-migration-examples.md
+++ b/docs/phase0/mirtoolbox-migration-examples.md
@@ -1,0 +1,43 @@
+# MIRtoolbox-style Migration Examples (Starter)
+
+> Goal: lower onboarding cost without forcing strict legacy compatibility.
+
+1. **Spectrum from file**
+   - Legacy style: `mirspectrum('song.wav')`
+   - New style: `ms.audio('song.wav').spectrum().compute()`
+
+2. **Tempo estimate**
+   - Legacy style: `mirtempo('song.wav')`
+   - New style: `ms.audio('song.wav').tempo().compute()`
+
+3. **Pitch curve**
+   - Legacy style: `mirpitch('song.wav')`
+   - New style: `ms.audio('song.wav').pitch().compute()`
+
+4. **Pulse clarity**
+   - Legacy style: `mirpulseclarity('song.wav')`
+   - New style: `ms.audio('song.wav').pulse_clarity().compute()`
+
+5. **MFCC extraction**
+   - Legacy style: `mirmfcc('song.wav')`
+   - New style: `ms.audio('song.wav').mfcc().compute()`
+
+6. **Batch spectrum**
+   - Legacy pattern: user loops over files
+   - New style: `ms.batch('/data/**/*.wav').pipeline(lambda x: x.spectrum()).run()`
+
+7. **Key estimation from symbolic file**
+   - Legacy style: separate symbolic routines
+   - New style: `ms.midi('piece.mid').key().compute()`
+
+8. **Complex chained analysis**
+   - Legacy style: nested calls
+   - New style: `ms.audio('song.wav').frame().spectrum().flux().tempo().compute()`
+
+9. **Custom parameterized analysis**
+   - Legacy style: long positional option lists
+   - New style: `ms.audio('song.wav').frame(size=0.05, hop=0.01).spectrum(scale='mel').compute()`
+
+10. **Reproducible run export**
+   - Legacy style: manual scripts/logging
+   - New style: `result.provenance.to_json('run-meta.json')`

--- a/docs/phase0/operator-plugin-skeletons.py
+++ b/docs/phase0/operator-plugin-skeletons.py
@@ -1,0 +1,42 @@
+"""Phase 0 skeletons: illustrative only (not production code)."""
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class Signal:
+    data: Any
+    srate: float | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class Operator(Protocol):
+    name: str
+
+    def __call__(self, x: Signal, **kwargs: Any) -> Signal:
+        ...
+
+
+class SpectrumOperator:
+    name = "spectrum"
+
+    def __call__(self, x: Signal, **kwargs: Any) -> Signal:
+        # TODO: replace with real implementation
+        return x
+
+
+class Plugin(Protocol):
+    plugin_name: str
+    version: str
+
+    def register(self, registry: dict[str, Operator]) -> None:
+        ...
+
+
+class ExamplePlugin:
+    plugin_name = "example_dsp"
+    version = "0.1.0"
+
+    def register(self, registry: dict[str, Operator]) -> None:
+        registry[SpectrumOperator.name] = SpectrumOperator()

--- a/docs/phase0/orpheon-bootstrap/.github/workflows/publish-pypi.yml
+++ b/docs/phase0/orpheon-bootstrap/.github/workflows/publish-pypi.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      # Option A: Trusted Publishing (recommended)
+      - name: Publish with Trusted Publishing
+        if: ${{ secrets.PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      # Option B: API token fallback
+      - name: Publish with API token
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/phase0/orpheon-bootstrap/README.md
+++ b/docs/phase0/orpheon-bootstrap/README.md
@@ -1,0 +1,5 @@
+# Orpheon (placeholder package)
+
+This placeholder release reserves the `orpheon` package name on PyPI.
+
+The first functional release will follow after the Phase 0 architecture sprint.

--- a/docs/phase0/orpheon-bootstrap/bootstrap-local.sh
+++ b/docs/phase0/orpheon-bootstrap/bootstrap-local.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstraps the current repository as the minimal Orpheon placeholder package
+# so the first PyPI reservation release can be created quickly.
+
+if [[ ! -f "pyproject.toml" ]]; then
+  echo "[info] No pyproject.toml found in current directory; proceeding."
+fi
+
+mkdir -p src/orpheon .github/workflows
+
+cp -f docs/phase0/orpheon-bootstrap/pyproject.toml pyproject.toml
+cp -f docs/phase0/orpheon-bootstrap/README.md README.md
+cp -f docs/phase0/orpheon-bootstrap/src/orpheon/__init__.py src/orpheon/__init__.py
+cp -f docs/phase0/orpheon-bootstrap/.github/workflows/publish-pypi.yml .github/workflows/publish-pypi.yml
+
+echo "[ok] Orpheon placeholder package files copied into current repository."
+echo "[next] Review files, then run:"
+echo "       git add pyproject.toml README.md src/orpheon .github/workflows/publish-pypi.yml"
+echo "       git commit -m 'Bootstrap placeholder package for PyPI reservation'"
+echo "       git tag v0.0.1"
+echo "       git push origin main --tags"

--- a/docs/phase0/orpheon-bootstrap/pyproject.toml
+++ b/docs/phase0/orpheon-bootstrap/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "orpheon"
+version = "0.0.1"
+description = "Placeholder package to reserve the Orpheon name on PyPI."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "BSD-3-Clause" }
+authors = [
+  { name = "Olivier Lartillot" }
+]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Multimedia :: Sound/Audio :: Analysis",
+]
+
+[project.urls]
+Homepage = "https://github.com/olivierlar/orpheon"
+Repository = "https://github.com/olivierlar/orpheon"
+Issues = "https://github.com/olivierlar/orpheon/issues"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/docs/phase0/orpheon-bootstrap/src/orpheon/__init__.py
+++ b/docs/phase0/orpheon-bootstrap/src/orpheon/__init__.py
@@ -1,0 +1,4 @@
+"""Orpheon placeholder package."""
+
+__all__ = ["__version__"]
+__version__ = "0.0.1"

--- a/docs/phase0/orpheon-validation-checklist.md
+++ b/docs/phase0/orpheon-validation-checklist.md
@@ -1,0 +1,30 @@
+# Orpheon Naming Validation (Updated with confirmed availability checks)
+
+Date: 2026-03-06
+
+## Summary
+Chosen candidate: **Orpheon**.
+
+This document records practical checklist items that were verifiable now, including externally confirmed results for GitHub and PyPI.
+
+## Results
+
+| Check | Method | Result | Status |
+|---|---|---|---|
+| GitHub org availability (`orpheon`) | Direct GitHub check | Name is already taken by an existing user account | ⚠️ Not available for org creation |
+| GitHub repo availability (`orpheon/orpheon`) | `GET https://api.github.com/repos/orpheon/orpheon` | Response `404 Not Found` | ✅ Available (repo does not exist) |
+| PyPI package availability (`orpheon`) | `https://pypi.org/project/orpheon/` | Page returns `404` | ✅ Likely available (no published package) |
+| Domain DNS signal (`orpheon.org`) | `getent hosts orpheon.org` | No DNS record returned in this environment at check time | ⚠️ Inconclusive |
+| Domain DNS signal (`orpheon.dev`) | `getent hosts orpheon.dev` | Resolves to `185.158.133.1` | ❗ Likely already registered |
+| Domain DNS signal (`orpheon.ai`) | `getent hosts orpheon.ai` | Resolves to `76.76.21.21` | ❗ Likely already registered |
+| In-repo naming conflict | `rg -n "Orpheon|orpheon" docs` | Only expected references in Phase 0 naming docs | ✅ Pass |
+
+## Interpretation
+- **Orpheon remains viable as software/package name**, even though the `orpheon` GitHub org/account namespace is already taken.
+- Domain strategy should not assume `.dev` or `.ai` availability.
+
+## Recommended immediate actions
+1. Keep software name **Orpheon**.
+2. Use an alternative GitHub namespace (e.g., `orpheon-project`, `orpheon-lab`, or maintainer namespace) and create repo `orpheon`.
+3. Reserve the PyPI project name by publishing an initial placeholder package when ready.
+4. (Optional) Domain strategy can be deferred for this research project.

--- a/docs/phase0/project-naming-options.md
+++ b/docs/phase0/project-naming-options.md
@@ -1,0 +1,96 @@
+# New Project Naming Options (Python-Ecosystem Inspired)
+
+## Why a fresh naming direction
+You asked for names that are **completely different** from the previous Modalis/Modalys family.
+This shortlist is therefore built from naming patterns frequently seen in Python ecosystems:
+- short coined technical names (`numpy`, `scipy`, `librosa`),
+- mythology/astronomy motifs (`pandas`, `polars`, `celery`, `orion`-style projects),
+- "lab/tool/kit"-style research framing.
+
+## Naming criteria
+- Distinct from MiningSuite and previous candidates.
+- Works for music/audio today and multimodality tomorrow.
+- Feels credible for an open-source scientific Python project.
+- Suitable as GitHub repo + PyPI package + import name.
+
+## Completely new shortlist
+
+### 1) **Orpheon**
+- **Inspiration:** Orpheus + scientific tool naming.
+- **Pros:** musical roots, elegant, not tied to legacy naming.
+- **Cons:** name-check availability needs verification.
+- **Import idea:** `import orpheon as op`
+
+### 2) **Helicon**
+- **Inspiration:** Mount Helicon (Muses) + classical research tone.
+- **Pros:** strong arts/science symbolism; broad enough for multimodality.
+- **Cons:** could be confused with existing products in other sectors.
+
+### 3) **Asteria**
+- **Inspiration:** astronomy/mythology style common in Python project names.
+- **Pros:** modern, broad, scalable brand for new modalities.
+- **Cons:** less explicit about audio/MIR without tagline.
+
+### 4) **Sonopy**
+- **Inspiration:** Pythonic suffix pattern (`-py`) + sound root.
+- **Pros:** instantly reads as Python package; easy to remember.
+- **Cons:** can appear audio-only unless messaging expands scope.
+
+### 5) **Musaic**
+- **Inspiration:** muse + mosaic (integration of modalities/toolboxes).
+- **Pros:** expressive, aligned with multimodal fusion narrative.
+- **Cons:** spelling may need reinforcement initially.
+
+### 6) **LyraLab**
+- **Inspiration:** constellation/instrument motif + research-lab framing.
+- **Pros:** clear academic/open-source flavor.
+- **Cons:** slightly longer package/repo name.
+
+### 7) **Auricore**
+- **Inspiration:** "auri" (hearing) + core-engine focus.
+- **Pros:** sounds technical and framework-oriented.
+- **Cons:** less obviously multimodal without supporting description.
+
+### 8) **Polymuse**
+- **Inspiration:** poly(modal) + muse.
+- **Pros:** naturally signals multimodality and creativity.
+- **Cons:** might feel more conceptual than engineering-focused.
+
+### 9) **Cadentis**
+- **Inspiration:** cadence + scientific suffix.
+- **Pros:** distinctive, professional tone.
+- **Cons:** indirect relation to analysis unless paired with tagline.
+
+### 10) **Nodara**
+- **Inspiration:** neutral coined name (graph nodes + data aura).
+- **Pros:** broad, future-proof across modalities.
+- **Cons:** meaning is less immediate; requires brand story.
+
+## Top recommendation (new direction)
+## **Orpheon**
+
+Validation update: PyPI package check returned `404 Not Found` (available), while GitHub `orpheon` is already occupied as an account name.
+
+GitHub namespace note: keep the product name **Orpheon** and host under an alternate org/user namespace (for example: `orpheon-project/orpheon`).
+
+
+Suggested positioning:
+- **Project name:** Orpheon
+- **Tagline:** *A Python framework for multimodal music and signal analysis.*
+- **Import example:** `import orpheon as op`
+
+Why this one:
+- Clearly different from prior naming branch.
+- Retains musical identity while remaining broad enough for motion/biosignal/video integration.
+- Feels aligned with scientific Python branding conventions.
+
+## Runner-up options
+1. **Asteria** (if you want a broader, modality-agnostic umbrella brand).
+2. **Sonopy** (if you want explicit Python discoverability first).
+
+## Practical validation checklist (before final choice)
+1. GitHub org and repository availability.
+2. PyPI package name availability.
+3. Basic trademark/conflict screening in target jurisdictions.
+4. Domain name availability (optional).
+5. Pronunciation and memorability check with collaborators and potential users.

--- a/docs/phase0/pypi-reservation-automation.md
+++ b/docs/phase0/pypi-reservation-automation.md
@@ -1,0 +1,47 @@
+# Automating PyPI Reservation for `orpheon`
+
+This document provides a ready workflow to reserve the `orpheon` package name on PyPI with a minimal placeholder release.
+
+## Recommended flow
+1. Bootstrap a minimal package from `docs/phase0/orpheon-bootstrap/` into your new repo (`olivierlar/orpheon`).
+2. Choose one publish method:
+   - **Trusted Publishing** (preferred), or
+   - **PyPI API token secret** (`PYPI_API_TOKEN`).
+3. Trigger the workflow by pushing a tag (for example `v0.0.1`).
+
+## Quick start commands (run inside your new `orpheon` repo)
+```bash
+cp -R /path/to/miningsuite/docs/phase0/orpheon-bootstrap/* .
+git add .
+git commit -m "Bootstrap placeholder package and PyPI publish workflow"
+git tag v0.0.1
+git push origin main --tags
+```
+
+## One-command local bootstrap (new)
+If you are inside this `miningsuite` workspace, you can generate a ready-to-run helper script:
+
+```bash
+bash docs/phase0/orpheon-bootstrap/bootstrap-local.sh
+```
+
+Then run the printed `git add/commit/tag/push` commands from your actual `olivierlar/orpheon` repository clone.
+
+## GitHub Actions secrets/setup
+### Option A — Trusted Publishing (preferred)
+- Configure PyPI "Trusted Publisher" for `olivierlar/orpheon` and workflow `.github/workflows/publish-pypi.yml`.
+- No API token is needed.
+
+### Option B — API token
+- Create a PyPI token with scope for project `orpheon` (or account-scoped for first publish).
+- Add repository secret: `PYPI_API_TOKEN`.
+- Workflow will use `__token__` as username and this secret as password.
+
+## Verifying reservation
+After a successful workflow run, confirm:
+- `https://pypi.org/project/orpheon/` is live.
+- `pip index versions orpheon` shows version `0.0.1` (or chosen version).
+
+## What still requires you (PI)
+- Pushing to `https://github.com/olivierlar/orpheon` (this environment cannot authenticate/push to your GitHub).
+- Configuring PyPI Trusted Publishing or adding `PYPI_API_TOKEN` in GitHub repository secrets.

--- a/docs/python-port-feasibility.md
+++ b/docs/python-port-feasibility.md
@@ -1,0 +1,101 @@
+# MiningSuite Python Redesign — Phase 0 Product & Architecture Charter
+
+## Decision summary (based on your priorities)
+This should be a **new Python-native framework**, not a strict compatibility clone.
+
+- Do **not** target MATLAB/MiningSuite/toolbox compatibility as a hard requirement.
+- Do preserve a **low-friction path for MIRtoolbox users** where it does not compromise architecture quality.
+- Keep the core user promise: **simple commands can build simple or complex analyses**.
+- Optimize for **throughput and scalability** (especially large batch processing), not real-time constraints.
+- Design the project as a true open-source platform where contributors can add modules easily.
+- Commit to **API stability** after the initial core maturation window.
+- Treat multimodality as a first-class direction (audio, symbolic, motion capture, and future signals such as biosignals).
+
+## Phase 0 goals (finalized)
+
+### 1) Product goals
+1. **Usability:** one-line and short-pipeline commands for common analyses.
+2. **Composability:** complex analysis graphs remain readable and declarative.
+3. **Scalability:** native support for large corpus analysis and resumable jobs.
+4. **Extensibility:** external contributors can add operators/modalities without editing core internals.
+5. **Stability:** clear versioned API policy once v1.0 is declared.
+
+### 2) Non-goals (for v1)
+- Real-time/live DSP guarantees.
+- Full behavioral parity with MATLAB implementation.
+- Full backward-compatibility with every historical default.
+
+### 3) User migration principle
+Adopt **guided familiarity**, not strict compatibility:
+- Keep recognizable operator naming patterns where useful to MIRtoolbox users.
+- Provide concise migration docs and command mapping examples.
+- Prefer better API design over legacy quirks when they conflict.
+
+## Proposed architecture principles
+
+### A. "Simple command" experience as a design constraint
+- Build a high-level front API that supports concise calls (single function / fluent pipeline / config recipe).
+- Make defaults musically meaningful and safe.
+- Ensure every result embeds enough metadata/provenance for reproducibility.
+
+### B. Layered architecture
+1. **Core data layer:** typed containers (`Signal`, `Feature`, `Sequence`, etc.) with units, axes, provenance.
+2. **Operator layer:** pure transforms with explicit input/output contracts.
+3. **Execution layer:** graph planner + scheduler for single file, batch, and distributed execution.
+4. **Interface layer:** simple user API + CLI + notebook-friendly display.
+5. **Plugin layer:** registration and discovery for community operators.
+
+### C. Performance model (non-real-time)
+- Optimize for offline throughput:
+  - chunked processing,
+  - parallel batch execution,
+  - caching/intermediate reuse,
+  - resumable failed runs,
+  - deterministic outputs.
+
+### D. Modality-first extensibility
+- Define a modality abstraction early (audio, symbolic/MIDI, MoCap, video, biosignal).
+- Enforce a common operator contract while allowing modality-specific adapters.
+- Ensure cross-modality fusion is possible via shared time/index alignment primitives.
+
+## Governance and open-source model (Phase 0 deliverables)
+1. **Contributor workflow:** module template, tests template, docs template.
+2. **Plugin policy:** what can live out-of-tree vs in core.
+3. **Review standards:** API review checklist + performance checklist + reproducibility checklist.
+4. **Versioning policy:** semantic versioning and explicit deprecation windows.
+5. **RFC/ADR process:** architecture changes require lightweight recorded decisions.
+
+## Concrete Phase 0 deliverables
+- `ADR-001`: Scope and non-goals.
+- `ADR-002`: API philosophy (guided familiarity vs strict compatibility).
+- `ADR-003`: Core data model and provenance requirements.
+- `ADR-004`: Operator contract and execution graph semantics.
+- `ADR-005`: Plugin system and extension points.
+- `ADR-006`: Batch execution and caching strategy.
+- `ADR-007`: API stability and deprecation policy.
+- Initial "MIRtoolbox user migration guide" skeleton.
+
+## Should we follow the previous migration plan?
+**Yes, with this adjustment:**
+- Keep the staged migration structure.
+- But gate implementation behind the Phase 0 charter above.
+- Start coding only after ADR-001..007 are accepted.
+
+So the plan becomes:
+1. **Phase 0 (this charter + ADRs)**
+2. Phase 1 core contracts
+3. Phase 2 compatibility/migration aids
+4. Phase 3 vertical slice
+5. Phase 4 package rollout
+6. Phase 5 hardening/stability
+
+## Recommended immediate next step
+Run a short architecture sprint (1–2 weeks) to finalize ADR-001..007 and produce:
+- minimal API mockups,
+- operator/plugin skeletons,
+- batch execution prototype spec,
+- migration examples for 5–10 common MIRtoolbox-style tasks.
+
+
+## Phase 0 starter artifacts
+The initial sprint artifacts are now scaffolded under `docs/phase0/` for review and iteration before implementation-heavy coding.


### PR DESCRIPTION
### Motivation
- Provide a self-contained Phase 0 starter pack to drive a 1–2 week architecture sprint for a Python-native redesign of MiningSuite, including ADRs, API mockups, migration examples, and a batch execution prototype spec.
- Reserve the `orpheon` PyPI package name by shipping a small placeholder bootstrap with workflow and helper script to simplify a first publish.
- Ensure common editor/OS artifacts and Python bytecode are ignored in the repo via `.gitignore` updates.

### Description
- Add a comprehensive `docs/phase0/` folder containing ADRs (`ADR-001`..`ADR-007`), `api-mockups.md`, `batch-execution-prototype-spec.md`, migration examples, an operator/plugin skeleton (`operator-plugin-skeletons.py`), and a high-level `python-port-feasibility.md` charter. 
- Add an `orpheon-bootstrap/` subfolder with a placeholder `pyproject.toml`, package `src/orpheon/__init__.py`, a publish GitHub Actions workflow, `README.md`, and an executable `bootstrap-local.sh` to copy bootstrap artifacts into a new repo.
- Add a `orpheon-validation-checklist.md`, `project-naming-options.md`, and `pypi-reservation-automation.md` to document name checks and automated publish flow.
- Update `.gitignore` to ignore Python cache/bytecode (`__pycache__/` and `*.py[cod]`) in addition to existing entries.

### Testing
- No automated tests were added for these documentation and bootstrap changes and no CI test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9419000b48324a79cb1cce855b4d6)